### PR TITLE
feat: refine experience & education

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -172,5 +172,8 @@
     "letsWorkTogether": "Let’s work together",
     "emailMe": "Email me",
     "contactDetails": "Contact details"
+  },
+  "experience": {
+    "updating": "Updating..."
   }
 }

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -179,5 +179,8 @@
     "letsWorkTogether": "Cùng hợp tác",
     "emailMe": "Liên hệ qua email",
     "contactDetails": "Thông tin liên hệ"
+  },
+  "experience": {
+    "updating": "Đang cập nhật..."
   }
 }

--- a/apps/web/src/app/[locale]/(public)/about/page.tsx
+++ b/apps/web/src/app/[locale]/(public)/about/page.tsx
@@ -6,7 +6,7 @@ import { getTranslations } from '@/lib/i18n';
 import { AboutContent } from '@/components/about-content';
 import { AboutShell } from '@/components/shell';
 import { TechGroup } from '@/components/tech-stack-group';
-import { TimelineItemProps } from '@/components/timeline';
+import { EducationTimelineItemProps } from '@/components/timeline';
 
 export default async function AboutPage() {
   const t = await getTranslations();
@@ -52,7 +52,7 @@ export default async function AboutPage() {
   );
 
   // Educations
-  const educationItems: TimelineItemProps[] = (user.educations || []).map(
+  const educationItems: EducationTimelineItemProps[] = (user.educations || []).map(
     (
       edu: Prisma.EducationGetPayload<{
         include: {

--- a/apps/web/src/app/[locale]/(public)/experience/page.tsx
+++ b/apps/web/src/app/[locale]/(public)/experience/page.tsx
@@ -1,7 +1,7 @@
 import { fetchData } from '@/lib/core/fetch';
-import ExperienceTimeline, {
+import ExperienceContent, {
   CompanyExperience,
-} from '@/components/experience-timeline';
+} from '@/components/experience-content';
 import { ExperienceShell } from '@/components/shell';
 
 export default async function ExperiencesPage() {
@@ -9,7 +9,7 @@ export default async function ExperiencesPage() {
 
   return (
     <ExperienceShell>
-      <ExperienceTimeline experienceData={experiences} />
+      <ExperienceContent experienceData={experiences} />
     </ExperienceShell>
   );
 }

--- a/apps/web/src/app/api/me/experience/route.ts
+++ b/apps/web/src/app/api/me/experience/route.ts
@@ -3,7 +3,7 @@ import { prisma } from '@db/client';
 
 import { ApiResponse } from '@/types/api';
 import { siteConfig } from '@/config/site';
-import { CompanyExperience } from '@/components/experience-timeline';
+import { CompanyExperience } from '@/components/experience-content';
 
 export async function GET() {
   try {

--- a/apps/web/src/components/about-content.tsx
+++ b/apps/web/src/components/about-content.tsx
@@ -7,7 +7,7 @@ import { GraduationCap, Layers, User as UserIcon } from 'lucide-react';
 import { useTranslations } from '@/hooks/use-translations';
 import { RichText } from '@/components/rich-text';
 import { TechGroup, TechStackGroup } from '@/components/tech-stack-group';
-import { Timeline, TimelineItemProps } from '@/components/timeline';
+import { EducationTimeline, EducationTimelineItemProps } from '@/components/timeline';
 
 const fadeInUp = {
   hidden: { opacity: 0, y: 24 },
@@ -21,7 +21,7 @@ const fadeInUp = {
 type AboutContentProps = {
   user: User;
   techGroups: TechGroup[];
-  educationItems: TimelineItemProps[];
+  educationItems: EducationTimelineItemProps[];
 };
 
 export function AboutContent({
@@ -71,28 +71,18 @@ export function AboutContent({
             </div>
           </div>
 
-          <Timeline
+          <EducationTimeline
             items={educationItems.map((item) => ({
               ...item,
               message: (
-                <div
-                  className="prose prose-sm max-w-none"
-                  dangerouslySetInnerHTML={{
-                    __html: item.message as string,
-                  }}
-                />
+                <RichText html={item.message as string} />
               ),
               subItems:
                 item.subItems &&
                 item.subItems.map((sub) => ({
                   title: sub.title,
                   message: (
-                    <div
-                      className="prose prose-sm max-w-none"
-                      dangerouslySetInnerHTML={{
-                        __html: sub.message as string,
-                      }}
-                    />
+                    <RichText html={sub.message as string} />
                   ),
                 })),
             }))}

--- a/apps/web/src/components/blog-manager.tsx
+++ b/apps/web/src/components/blog-manager.tsx
@@ -41,6 +41,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { RichText } from '@/components/rich-text';
 import { RichTextEditor } from '@/components/rich-text-editor';
 import { SubmitButton } from '@/components/submit-button';
+import { TrashButton } from '@/components/trash-button';
 
 type Blog = Prisma.BlogGetPayload<{
   include: {
@@ -244,17 +245,14 @@ export function BlogManager({
                 Tags: {blog.tags.map((t) => t.tag.name).join(', ')}
               </p>
             </CardContent>
-            <Button
-              size="icon"
-              variant="destructive"
+
+            <TrashButton
               className="absolute top-2 right-2"
               onClick={(e) => {
                 e.stopPropagation();
                 setDeleteConfirmId(blog.id);
               }}
-            >
-              <Trash className="h-4 w-4" />
-            </Button>
+            />
           </Card>
         ))}
       </div>

--- a/apps/web/src/components/dashboard-sidebar.tsx
+++ b/apps/web/src/components/dashboard-sidebar.tsx
@@ -3,7 +3,7 @@
 import { Link, usePathname } from '@/i18n/navigation';
 import {
   Briefcase,
-  Code2,
+  Code2, DatabaseZap,
   ExternalLink,
   FileText,
   GraduationCap,
@@ -19,6 +19,8 @@ import { signOut } from 'next-auth/react';
 import { useLocale } from 'next-intl';
 
 import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { clearCache } from '@/lib/actions/revalidate';
 
 const navItems = [
   { href: '/dashboard', label: 'Overview', icon: LayoutDashboard },
@@ -83,6 +85,16 @@ export function DashboardSidebar({ user }: DashboardSidebarProps) {
 
         {/* ================= FOOTER ================= */}
         <div className="space-y-1 border-t p-3">
+          {/* View public site */}
+          <Button
+            variant={'ghost'}
+            className="flex self-stretch w-full gap-3 rounded-md justify-start"
+            onClick={() => clearCache()}
+          >
+            <DatabaseZap className={'size-4'}/>
+            Clear all caches
+          </Button>
+
           {/* View public site */}
           <Link
             target={'_blank'}

--- a/apps/web/src/components/education-manager.tsx
+++ b/apps/web/src/components/education-manager.tsx
@@ -30,6 +30,7 @@ import { Label } from '@/components/ui/label';
 import { useToast } from '@/components/ui/use-toast';
 import { RichTextEditor } from '@/components/rich-text-editor';
 import { TrashButton } from '@/components/trash-button';
+import { SubmitButton } from '@/components/submit-button';
 
 type Education = Prisma.EducationGetPayload<{
   include: { subItems: true };
@@ -58,6 +59,7 @@ export function EducationManager({
   const [iconFile, setIconFile] = useState<File | null>(null);
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
   const editorRef = useRef<Editor>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleInputChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -100,6 +102,7 @@ export function EducationManager({
 
   const handleSubmit = async () => {
     try {
+      setIsSubmitting(true);
       let iconBase64 = formData.icon || null;
 
       if (iconFile) {
@@ -168,6 +171,8 @@ export function EducationManager({
         description: 'Failed to save education',
         variant: 'destructive',
       });
+    } finally {
+      setIsSubmitting(false)
     }
   };
 
@@ -278,7 +283,7 @@ export function EducationManager({
             </CardContent>
             <TrashButton
               className="absolute top-2 right-2"
-              removeFunc={() => {
+              onClick={() => {
                 setDeleteConfirmId(education.id);
               }}
             />
@@ -295,10 +300,10 @@ export function EducationManager({
           </DialogHeader>
 
           <div className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
+            <fieldset disabled={isSubmitting} className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label className={'font-bold'} htmlFor="timeline">
-                  Timeline
+                  EducationTimeline
                 </Label>
                 <Input
                   id="timeline"
@@ -319,7 +324,7 @@ export function EducationManager({
                   onChange={handleInputChange}
                 />
               </div>
-            </div>
+            </fieldset>
 
             <div className="space-y-2">
               <Label className={'font-bold'}>Message</Label>
@@ -366,7 +371,7 @@ export function EducationManager({
                           updateSubItemTitle(index, e.target.value)
                         }
                       />
-                      <TrashButton className={''} removeFunc={() => deleteSubItem(index)}/>
+                      <TrashButton className={''} onClick={() => deleteSubItem(index)}/>
                     </div>
 
                     <RichTextEditor
@@ -390,7 +395,7 @@ export function EducationManager({
             <Button variant="outline" onClick={resetForm}>
               Cancel
             </Button>
-            <Button onClick={handleSubmit}>Save</Button>
+            <SubmitButton loading={isSubmitting} onClick={handleSubmit}>Save</SubmitButton>
           </DialogFooter>
         </DialogContent>
       </Dialog>
@@ -412,9 +417,9 @@ export function EducationManager({
             <Button variant="outline" onClick={() => setDeleteConfirmId(null)}>
               No
             </Button>
-            <Button variant="destructive" onClick={handleDelete}>
+            <SubmitButton loading={isSubmitting} variant="destructive" onClick={handleDelete}>
               Yes
-            </Button>
+            </SubmitButton>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/apps/web/src/components/experience-content.tsx
+++ b/apps/web/src/components/experience-content.tsx
@@ -7,10 +7,9 @@ import { motion } from 'framer-motion';
 import { DateHelper } from '@/lib/core/date-helper';
 import { RichText } from '@/components/rich-text';
 import { TechstacksProject } from '@/components/techstacks-project';
-
-
-
-
+import { Empty, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
+import { Building2, FolderCode } from 'lucide-react';
+import { useTranslations } from '@/hooks/use-translations';
 
 export type CompanyExperience = Prisma.ExperienceGetPayload<{
   include: {
@@ -27,22 +26,23 @@ export type CompanyExperience = Prisma.ExperienceGetPayload<{
   };
 }>;
 
-export type ExperienceTimelineProps = BaseComponentProps & {
+export type ExperienceContentProps = BaseComponentProps & {
   experienceData: CompanyExperience[];
 };
 
-export default function ExperienceTimeline({
+export default function ExperienceContent({
                                              experienceData,
                                              className,
                                              style,
-                                           }: ExperienceTimelineProps) {
+                                           }: ExperienceContentProps) {
+  const t = useTranslations('experience');
   return (
     <section
       className={`mx-auto max-w-4xl px-4 py-12 md:py-16 ${className}`}
       style={style}
     >
       <div className="space-y-14">
-        {experienceData.map((company, idx) => (
+        {experienceData?.length ? experienceData.map((company, idx) => (
           <motion.div
             key={idx}
             initial={{ opacity: 0, y: 24 }}
@@ -116,7 +116,16 @@ export default function ExperienceTimeline({
               </div>
             </div>
           </motion.div>
-        ))}
+        )) :
+          <Empty className={className} style={style}>
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <Building2 />
+              </EmptyMedia>
+              <EmptyTitle>{t('updating')}</EmptyTitle>
+            </EmptyHeader>
+          </Empty>
+        }
       </div>
     </section>
   );

--- a/apps/web/src/components/experience-manager.tsx
+++ b/apps/web/src/components/experience-manager.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { EditorState } from 'draft-js';
 import { stateToHTML } from 'draft-js-export-html';
 import { stateFromHTML } from 'draft-js-import-html';
-import { CalendarIcon, Plus, Trash } from 'lucide-react';
+import { CalendarIcon, Plus } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -39,6 +39,7 @@ import {
 } from '@/components/ui/popover';
 import { RichTextEditor } from '@/components/rich-text-editor';
 import { TrashButton } from '@/components/trash-button';
+import { SubmitButton } from '@/components/submit-button';
 
 type Experience = Prisma.ExperienceGetPayload<{
   include: {
@@ -89,6 +90,7 @@ export function ExperienceManager({
   >([]);
   const [logoFile, setLogoFile] = useState<File | null>(null);
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
@@ -171,6 +173,7 @@ export function ExperienceManager({
 
   const handleSubmit = async () => {
     try {
+      setIsSubmitting(true);
       let logoBase64 = formData.logoUrl;
       if (logoFile) {
         logoBase64 = await FileHelper.fileToBase64(logoFile);
@@ -229,6 +232,9 @@ export function ExperienceManager({
         description: 'Failed to save experience',
         variant: 'destructive',
       });
+    }
+    finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -356,10 +362,12 @@ export function ExperienceManager({
 
             <TrashButton
               className="absolute top-2 right-2"
-              removeFunc={() => {
+              onClick={(e) => {
+                e.stopPropagation();
                 setDeleteConfirmId(experience.id);
               }}
             />
+
           </Card>
         ))}
       </div>
@@ -372,7 +380,7 @@ export function ExperienceManager({
             </DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
+            <fieldset disabled={isSubmitting} className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label htmlFor="company">Company</Label>
                 <Input
@@ -391,7 +399,7 @@ export function ExperienceManager({
                   onChange={handleInputChange}
                 />
               </div>
-            </div>
+            </fieldset>
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label htmlFor="type">Type</Label>
@@ -560,7 +568,7 @@ export function ExperienceManager({
 
                           <TrashButton
                             className="absolute top-2 right-8"
-                            removeFunc={() => deleteTask(roleIndex, taskIndex)}
+                            onClick={() => deleteTask(roleIndex, taskIndex)}
                           />
                         </div>
                       ))}
@@ -575,7 +583,7 @@ export function ExperienceManager({
 
                   <TrashButton
                     className="absolute top-2 right-2"
-                    removeFunc={() => deleteRole(roleIndex)}
+                    onClick={() => deleteRole(roleIndex)}
                   />
                 </Card>
               ))}
@@ -589,7 +597,7 @@ export function ExperienceManager({
             <Button variant="outline" onClick={resetForm}>
               Cancel
             </Button>
-            <Button onClick={handleSubmit}>Save</Button>
+            <SubmitButton loading={isSubmitting} onClick={handleSubmit}>Save</SubmitButton>
           </DialogFooter>
         </DialogContent>
       </Dialog>
@@ -611,9 +619,9 @@ export function ExperienceManager({
             <Button variant="outline" onClick={() => setDeleteConfirmId(null)}>
               Cancel
             </Button>
-            <Button variant="destructive" onClick={handleDelete}>
+            <SubmitButton loading={isSubmitting} variant="destructive" onClick={handleDelete}>
               Delete
-            </Button>
+            </SubmitButton>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/apps/web/src/components/project-manager.tsx
+++ b/apps/web/src/components/project-manager.tsx
@@ -196,7 +196,10 @@ export function ProjectManager({
             </CardContent>
             <TrashButton
               className="absolute top-2 right-2"
-              removeFunc={() => setDeleteConfirmId(project.id)}
+              onClick={(e) => {
+                e.stopPropagation();
+                setDeleteConfirmId(project.id);
+              }}
             />
           </Card>
         ))}

--- a/apps/web/src/components/rich-text.tsx
+++ b/apps/web/src/components/rich-text.tsx
@@ -14,26 +14,16 @@ export function RichText({ html, className, style }: RichTextProps) {
   return (
     <span
       className={cn(
-        'text-neutral-200 font-normal leading-7',
-
-        '[&_h1]:text-neutral-100 [&_h1]:text-2xl [&_h1]:font-semibold',
-        '[&_h2]:text-neutral-100 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:mt-6',
-        '[&_h3]:text-neutral-100 [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:mt-4',
+        // base
+        'font-normal leading-7',
 
         // paragraph
-        '[&_p]:my-3',
+        '[&_p]:my-3 [&_p]:text-neutral-800 dark:[&_p]:text-neutral-200',
 
-        // links
-        '[&_a]:text-neutral-300 hover:[&_a]:text-white',
-
-        // lists
-        '[&_li]:marker:text-neutral-500',
-
-        // code
-        '[&_code]:text-neutral-100 [&_code]:bg-white/5 [&_code]:px-1 [&_code]:rounded',
-
-        // blockquote
-        '[&_blockquote]:border-l-2 [&_blockquote]:border-neutral-500 [&_blockquote]:pl-4 [&_blockquote]:text-neutral-300',
+        // headings
+        '[&_h1]:text-neutral-900 dark:[&_h1]:text-neutral-100 [&_h1]:text-2xl [&_h1]:font-semibold',
+        '[&_h2]:text-neutral-900 dark:[&_h2]:text-neutral-100 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:mt-6',
+        '[&_h3]:text-neutral-900 dark:[&_h3]:text-neutral-100 [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:mt-4',
 
         className
       )}

--- a/apps/web/src/components/timeline.tsx
+++ b/apps/web/src/components/timeline.tsx
@@ -12,7 +12,7 @@ export interface SubItem {
   icon?: ReactNode;
 }
 
-export interface TimelineItemProps {
+export interface EducationTimelineItemProps {
   timeline: string | Date;
   title: ReactNode;
   message: ReactNode;
@@ -24,14 +24,14 @@ export interface TimelineItemProps {
   style?: React.CSSProperties;
 }
 
-export interface TimelineProps {
+export interface EducationTimelineProps {
   title?: string;
-  items: TimelineItemProps[];
+  items: EducationTimelineItemProps[];
   className?: string;
   style?: React.CSSProperties;
 }
 
-export function TimelineItem({
+export function EducationTimelineItem({
                                timeline,
                                title,
                                message,
@@ -41,8 +41,8 @@ export function TimelineItem({
                                subItems = [],
                                className,
                                style,
-                             }: TimelineItemProps) {
-  const displayTimeline =
+                             }: EducationTimelineItemProps) {
+  const displayEducationTimeline =
     typeof timeline === 'string'
       ? timeline
       : timeline.toLocaleDateString();
@@ -56,12 +56,12 @@ export function TimelineItem({
     >
       <div className="my-2 first:mt-0">
         <h3 className="text-sm md:text-base font-semibold uppercase tracking-wide text-muted-foreground">
-          {displayTimeline}
+          {displayEducationTimeline}
         </h3>
       </div>
 
       <div className={`flex gap-x-4 ${className}`} style={style}>
-        {/* Timeline rail */}
+        {/* EducationTimeline rail */}
         <div className="relative flex flex-col items-center">
           <motion.span
             initial={{ scaleY: 0 }}
@@ -155,13 +155,13 @@ export function TimelineItem({
 }
 
 
-export function Timeline({ title, items, className, style }: TimelineProps) {
+export function EducationTimeline({ title, items, className, style }: EducationTimelineProps) {
   return (
     <div className={`flex flex-col gap-3 ${className}`} style={style}>
       {title && <h2 className="text-xl md:text-2xl font-bold">{title}</h2>}
       <div className="space-y-4">
         {items.map((item, index) => (
-          <TimelineItem key={index} {...item} />
+          <EducationTimelineItem key={index} {...item} />
         ))}
       </div>
     </div>

--- a/apps/web/src/components/trash-button.tsx
+++ b/apps/web/src/components/trash-button.tsx
@@ -1,15 +1,15 @@
 import { Trash } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
-import { Button } from '@/components/ui/button';
+import { Button, ButtonProps } from '@/components/ui/button';
 
 export type TrashButtonProps = BaseComponentProps & {
-  removeFunc?: () => void;
+  onClick?: ButtonProps['onClick'];
   disabled?: boolean;
 };
 
 export function TrashButton({
-                              removeFunc,
+                              onClick,
                               className,
                               style,
                               disabled,
@@ -20,7 +20,7 @@ export function TrashButton({
       variant="ghost"
       size="icon"
       disabled={disabled}
-      onClick={removeFunc}
+      onClick={onClick}
       style={style}
       className={cn(
         `

--- a/apps/web/src/lib/actions/revalidate.ts
+++ b/apps/web/src/lib/actions/revalidate.ts
@@ -1,0 +1,7 @@
+'use server';
+
+import { revalidateTag } from 'next/cache';
+
+export async function clearCache(tag: string = 'all') {
+  revalidateTag(tag, 'max');
+}

--- a/apps/web/src/lib/core/fetch.ts
+++ b/apps/web/src/lib/core/fetch.ts
@@ -26,14 +26,13 @@ export async function fetchData<T>(
       searchParams.append(key, value);
     }
   }
-
   api += `?${searchParams.toString()}`;
 
   const resp = await fetch(api, {
     cache,
     next: {
       revalidate: revalidateTime,
-      tags: [`${endpoint}`],
+      tags: [`all`,`${endpoint}`],
     },
   });
 
@@ -44,34 +43,4 @@ export async function fetchData<T>(
 
   const { data }: ApiResponse<T> = await resp.json();
   return data;
-}
-
-export async function fetchREADMEData(
-  githubUrl: string,
-  { cache }: FetchOptions = { cache: 'force-cache' }
-): Promise<string> {
-  const match = githubUrl.match(/github\.com\/([^/]+\/[^/]+)/);
-  const repo = match?.[1];
-  if (!repo) {
-    throw new Error(`Cannot extract repo from URL: ${githubUrl}`);
-  }
-
-  const readmeCandidates = ['README.md', 'readme.md', 'Readme.md'];
-  for (const file of readmeCandidates) {
-    const url = `https://raw.githubusercontent.com/${repo}/main/${file}`;
-    const resp = await fetch(url, {
-      cache,
-      next: {
-        revalidate: revalidateTime,
-        tags: [githubUrl],
-      },
-    });
-
-    if (resp.ok) {
-      const readme = await resp.text();
-      return resolveRelativeImages(readme, githubUrl);
-    }
-  }
-
-  throw new Error(`README.md not found in ${repo}`);
 }

--- a/apps/web/src/lib/schemas/education.ts
+++ b/apps/web/src/lib/schemas/education.ts
@@ -10,7 +10,7 @@ export const educationSchema = z.object({
   timeline: z
     .string()
     .trim()
-    .min(1, 'Timeline is required')
+    .min(1, 'EducationTimeline is required')
     .max(100),
 
   title: z


### PR DESCRIPTION
## Summary by Sourcery

Refine the experience and education management and display flows, improve rich text styling, and add cache invalidation support.

New Features:
- Add a cache clearing action and dashboard control to invalidate cached content via a shared revalidation tag.
- Show an empty-state experience view with localized messaging when no experience data is available.

Bug Fixes:
- Prevent unintended dialog closure or navigation when clicking trash icons by stopping event propagation on delete actions.

Enhancements:
- Tag all data fetches with a shared cache tag to support global revalidation alongside endpoint-specific tags.
- Refine the education timeline component API and naming, and standardize its usage across the about page.
- Improve the rich text component styling for headings and paragraphs with light and dark mode support.
- Add loading and disabled states to experience and education management dialogs via a shared submit button component and submission state tracking.
- Simplify and generalize the trash button component API to use a standard onClick handler.

Chores:
- Remove the unused README fetch helper from the core fetch module.